### PR TITLE
Do not activate plugin on require

### DIFF
--- a/lib/dragonfly_svg.rb
+++ b/lib/dragonfly_svg.rb
@@ -1,7 +1,3 @@
 require "dragonfly"
 require "dragonfly_svg/plugin"
 require "dragonfly_svg/version"
-
-Dragonfly.app.configure do
-  plugin :svg
-end


### PR DESCRIPTION
Bundler requires all gems automatically. 

This plugin tend to activate itself on the `:default` Dragonfly app if it gets required, while in the README is noted that one has to activate it manually.

Activating this plugin explicitely on the preffered Dragonfly app is better than magically activating it.
