### PR TITLE
Fix README about set_view_box

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ svg.set_preserve_aspect_ratio('foo')  # preserveAspectRatio="foo"
 Sets the `viewBox` attribute of the SVG. Takes four parameters: `min_x`, `min_y`, `width` and `height`.
 
 ```ruby
-svg.set_viewbox(0, 0, 400, 600)       # viewBox="0 0 400 600"
+svg.set_view_box(0, 0, 400, 600)       # viewBox="0 0 400 600"
 ```
 
 ## Contributing


### PR DESCRIPTION
It seems to define `set_view_box`, not `set_viewbox`.
https://github.com/tomasc/dragonfly_svg/blob/19862c330dc979cd2aac90d8c4a702f6a0c9ae73/lib/dragonfly_svg/plugin.rb#L42